### PR TITLE
Add `skip-validation` flag; Remove default save path

### DIFF
--- a/cmd/template-resolver/client_test.go
+++ b/cmd/template-resolver/client_test.go
@@ -87,7 +87,7 @@ func cliTest(testName string) func(t *testing.T) {
 		saveResources := filepath.Join(tmpDir, "save_resources.yaml")
 
 		resolvedYAML, err := utils.ProcessTemplate(inputBytes, kcPath, clusterName,
-			hubNS, objNamespace, objName, saveResources, saveHubResources)
+			hubNS, objNamespace, objName, saveResources, saveHubResources, false)
 		if err != nil {
 			if len(errorBytes) == 0 {
 				t.Fatal(err)

--- a/cmd/template-resolver/utils/resolver_client.go
+++ b/cmd/template-resolver/utils/resolver_client.go
@@ -16,7 +16,7 @@ type TemplateResolver struct {
 	objNamespace      string
 	objName           string
 	saveResources     string
-	// saveHubResources Output doesn't include "ManagedClusters" resources,
+	// saveHubResources Output doesn't include "ManagedClusters" resources
 	saveHubResources string
 }
 
@@ -41,24 +41,28 @@ func (t *TemplateResolver) GetCmd() *cobra.Command {
 		"",
 		"the input kubeconfig to also resolve hub templates",
 	)
+
 	templateResolverCmd.Flags().StringVar(
 		&t.clusterName,
 		"cluster-name",
 		"",
 		"the cluster name to use for the .ManagedClusterName template variable when resolving hub cluster templates",
 	)
+
 	templateResolverCmd.Flags().StringVar(
 		&t.hubNamespace,
 		"hub-namespace",
 		"",
 		"the namespace on the hub to restrict namespaced lookups to when resolving hub templates",
 	)
+
 	templateResolverCmd.Flags().StringVar(
 		&t.objNamespace,
 		"object-namespace",
 		"",
 		"the object namespace to use for the .ObjectNamespace template variable when policy uses namespaceSelector",
 	)
+
 	templateResolverCmd.Flags().StringVar(
 		&t.objName,
 		"object-name",
@@ -70,7 +74,7 @@ func (t *TemplateResolver) GetCmd() *cobra.Command {
 	templateResolverCmd.Flags().StringVar(
 		&t.saveResources,
 		"save-resources",
-		"s",
+		"",
 		"the path to save the output containing resources used. "+
 			"This output can be used as input resources for the dry-run CLI or for local environment testing.",
 	)
@@ -78,7 +82,7 @@ func (t *TemplateResolver) GetCmd() *cobra.Command {
 	templateResolverCmd.Flags().StringVar(
 		&t.saveHubResources,
 		"save-hub-resources",
-		"s",
+		"",
 		"the path to save the output containing resources used in the hub cluster. "+
 			"This output can be used as input resources for the dry-run CLI or for local environment testing.",
 	)

--- a/cmd/template-resolver/utils/resolver_client.go
+++ b/cmd/template-resolver/utils/resolver_client.go
@@ -18,6 +18,7 @@ type TemplateResolver struct {
 	saveResources     string
 	// saveHubResources Output doesn't include "ManagedClusters" resources
 	saveHubResources string
+	skipValidation   bool
 }
 
 func (t *TemplateResolver) GetCmd() *cobra.Command {
@@ -87,6 +88,13 @@ func (t *TemplateResolver) GetCmd() *cobra.Command {
 			"This output can be used as input resources for the dry-run CLI or for local environment testing.",
 	)
 
+	templateResolverCmd.Flags().BoolVar(
+		&t.skipValidation,
+		"skip-validation",
+		false,
+		"Handle the input directly as a Go template, skipping any surrounding policy field validations.",
+	)
+
 	return templateResolverCmd
 }
 
@@ -124,8 +132,8 @@ func (t *TemplateResolver) resolveTemplates(cmd *cobra.Command, args []string) e
 		return fmt.Errorf("error handling YAML file input: %w", err)
 	}
 
-	resolvedYAML, err := ProcessTemplate(yamlBytes, t.hubKubeConfigPath,
-		t.clusterName, t.hubNamespace, t.objNamespace, t.objName, t.saveResources, t.saveHubResources)
+	resolvedYAML, err := ProcessTemplate(yamlBytes, t.hubKubeConfigPath, t.clusterName, t.hubNamespace,
+		t.objNamespace, t.objName, t.saveResources, t.saveHubResources, t.skipValidation)
 	if err != nil {
 		cmd.Printf("error processing templates: %s\n", err.Error())
 

--- a/cmd/template-resolver/utils/resolver_utils.go
+++ b/cmd/template-resolver/utils/resolver_utils.go
@@ -75,7 +75,7 @@ func HandleFile(yamlFile string) ([]byte, error) {
 // an error if any failures are found. It uses the `hubKubeConfigPath`, `hubNS` and `clusterName`
 // to establish a dynamic client with the hub to resolve any hub templates it finds.
 func ProcessTemplate(yamlBytes []byte, hubKubeConfigPath, clusterName, hubNS,
-	objNamespace, objName, saveResourcesPath, saveHubResourcesPath string,
+	objNamespace, objName, saveResourcesPath, saveHubResourcesPath string, skipValidation bool,
 ) ([]byte, error) {
 	policy := unstructured.Unstructured{}
 
@@ -213,12 +213,23 @@ func ProcessTemplate(yamlBytes []byte, hubKubeConfigPath, clusterName, hubNS,
 	case "OperatorPolicy":
 		_, err = processOperatorPolicyTemplates(policy.Object, resolver, tempCtx)
 	default:
-		if _, ok := policy.Object["object-templates-raw"]; !ok {
-			return nil, errors.New("invalid YAML. Supported types: Policy, " +
-				"ConfigurationPolicy, OperatorPolicy, object-templates-raw")
-		}
+		if skipValidation {
+			var resolvedRaw any
+			resolvedRaw, err = processRawGoTemplate(string(yamlBytes), resolver, tempCtx)
 
-		err = processObjTemplatesRaw(&policy, resolver, tempCtx)
+			if resolved, ok := resolvedRaw.(map[string]interface{}); ok {
+				policy.Object = resolved
+			} else {
+				err = errors.New("failed to cast returned object to map[string]interface{}")
+			}
+		} else {
+			if _, ok := policy.Object["object-templates-raw"]; !skipValidation && !ok {
+				return nil, errors.New("invalid YAML. Supported types: Policy, " +
+					"ConfigurationPolicy, OperatorPolicy, object-templates-raw")
+			}
+
+			err = processObjTemplatesRaw(&policy, resolver, tempCtx)
+		}
 	}
 
 	if err != nil {
@@ -352,33 +363,44 @@ func processConfigPolicyTemplate(
 	return nil
 }
 
+func processRawGoTemplate(
+	input string,
+	resolver *templates.TemplateResolver,
+	tempCtx templates.TemplateContext,
+) (resolved any, err error) {
+	resolveOptions := templates.ResolveOptions{InputIsYAML: true}
+
+	if strings.Contains(input, "{{hub") {
+		return nil, errors.New("unresolved hub template in YAML input. Use the hub-kubeconfig argument")
+	}
+
+	tmplResult, err := resolver.ResolveTemplate([]byte(input), tempCtx, &resolveOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process the templates: %w", err)
+	}
+
+	err = json.Unmarshal(tmplResult.ResolvedJSON, &resolved)
+	if err != nil {
+		return nil, fmt.Errorf("failed to process the templates: %w", err)
+	}
+
+	return
+}
+
 // processObjTemplatesRaw takes a YAML string representation and resolves the object's managed templates
 func processObjTemplatesRaw(
 	raw *unstructured.Unstructured,
 	resolver *templates.TemplateResolver,
 	tempCtx templates.TemplateContext,
 ) error {
-	resolveOptions := templates.ResolveOptions{InputIsYAML: true}
-
 	oTRaw, _, _ := unstructured.NestedString(raw.Object, "object-templates-raw")
 	if oTRaw == "" {
 		return errors.New("invalid object-templates-raw after resolving hub templates")
 	}
 
-	if strings.Contains(oTRaw, "{{hub") {
-		return errors.New("unresolved hub template in YAML input. Use the hub-kubeconfig argument")
-	}
-
-	tmplResult, err := resolver.ResolveTemplate([]byte(oTRaw), tempCtx, &resolveOptions)
+	resolved, err := processRawGoTemplate(oTRaw, resolver, tempCtx)
 	if err != nil {
-		return fmt.Errorf("failed to process the templates: %w", err)
-	}
-
-	var resolved interface{}
-
-	err = json.Unmarshal(tmplResult.ResolvedJSON, &resolved)
-	if err != nil {
-		return fmt.Errorf("failed to process the templates: %w", err)
+		return err
 	}
 
 	var objectTemplates []interface{}


### PR DESCRIPTION
Feature:
- Adds a `--skip-validation` flag in order to do things like (you know, just off the top of my head :joy:):
  ```shell
  str='{{ toYAML (set (fromYAML (fromConfigMap "default" "example" "file.yml")) "greeting" "hello") }}'
  echo "test: '${str}'" | template-resolver --skip-validation
  echo "test: |
    ${str}" | template-resolver --skip-validation
  ```

Fix:
- Removes the default `s` from save resources so that resources are not saved by default.